### PR TITLE
Garantis les versions des dépendances installées

### DIFF
--- a/.github/workflows/deploiement.yml
+++ b/.github/workflows/deploiement.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Installer la CLI Clever Cloud
         shell: bash
-        run: npm install -g clever-tools
+        run: npm install -g clever-tools@4.4.0
 
       - name: Déployer en DÉMO
         env:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Installer la CLI Clever Cloud
         shell: bash
-        run: npm install -g clever-tools
+        run: npm install -g clever-tools@4.4.0
 
       - name: Déployer en PROD
         env:

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 npm ci
-npx knex migrate:latest
+./node_modules/.bin/knex migrate:latest

--- a/scripts/migrations.sh
+++ b/scripts/migrations.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
-npm install
+npm ci
 npx knex migrate:latest


### PR DESCRIPTION
On souhaite que le package-lock.json fasse foi. Pour cela, on se débarasse des mécanismes qui installent des dépendences à des versions non épinglées.